### PR TITLE
Add log-async/plain fn to log without metadata

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.sparx/kits "1.20.2"
+(defproject org.clojars.sparx/kits "1.20.3"
   :description "Runa's core utilities."
   :local-repo ".m2"
   :min-lein-version "2.0.0"

--- a/src/kits/logging/log_async.clj
+++ b/src/kits/logging/log_async.clj
@@ -41,6 +41,10 @@
   ([msg] (info log-q msg))
   ([queue msg] (q/add @queue (assoc msg :log-level :INFO))))
 
+(defn plain
+  ([msg] (plain log-q msg))
+  ([queue msg] (q/add @queue (assoc msg :log-level :PLAIN))))
+
 (defn debug
   ([msg] (debug log-q msg))
   ([queue msg] (q/add @queue (assoc msg :log-level :DEBUG))))

--- a/src/kits/logging/log_generator.clj
+++ b/src/kits/logging/log_generator.clj
@@ -32,10 +32,18 @@
       (.append \newline)
       (.toString)))
 
+(defn log-line-plain [^String message]
+  (-> (StringBuilder. 256)
+      (.append message)
+      (.append \newline)
+      (.toString)))
+
 (defn log-formatter [default-context msg-map]
   (let [log-level (get-in msg-map ["log-level"] :INFO)
         context (get-in msg-map [:reply "context"] default-context)]
-    (log-line log-level context (str msg-map) nil)))
+    (if (= log-level :PLAIN)
+      (log-line-plain (str msg-map))
+      (log-line log-level context (str msg-map) nil))))
 
 (defn simple-date-format
   ([format-string]


### PR DESCRIPTION
log/plain is a new fn that  does not add any metadata(Log-level, timestamp etc). It instead logs the message as is.