### PR TITLE
Fix ->timestamp name conflict. kits.timestamp.->Timestamp renamed.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject staples-sparx/kits "1.32.5"
+(defproject staples-sparx/kits "1.33.0"
   :description "Staples SparX core libraries."
   :local-repo ".m2"
   :min-lein-version "2.0.0"

--- a/src/clojure/kits/timestamp.clj
+++ b/src/clojure/kits/timestamp.clj
@@ -240,7 +240,7 @@
 (defn ->sql-time [timestamp]
   (->str timestamp yyyy-mm-dd-hh-mm-ss-SSS))
 
-(defn ->Timestamp
+(defn ->SQLTimestamp
   "Creating a UTC string and parsing it adjusts the timezone
    properly. (Timestamp. millis) alters the millis into the local timezone"
   [ts]


### PR DESCRIPTION
Fixes a classloader error due to a naming conflict. 

> java.lang.NoClassDefFoundError: kits/timestamp$__GT_timestamp (wrong name: kits/timestamp$__GT_Timestamp), compiling:(zaphod/promo_bank/dot_com.clj:1:1)
>         at clojure.lang.Compiler.load(Compiler.java:7391)
